### PR TITLE
Return an initial empty response for /stream

### DIFF
--- a/flask_sse.py
+++ b/flask_sse.py
@@ -133,6 +133,10 @@ class ServerSentEventsBlueprint(Blueprint):
         """
         A generator of :class:`~flask_sse.Message` objects from the given channel.
         """
+
+        # Return an initial response to the request.
+        yield b''
+
         pubsub = self.redis.pubsub()
         pubsub.subscribe(channel)
         for pubsub_message in pubsub.listen():


### PR DESCRIPTION
Provides an initial response to the request to /stream.

Chome shows requests to /stream as being in a `pending` state until some message is published. The minor addition of yielding an empty string in the `messages` response generator seems to get the headers downstream so web server / client can better know the status of the request. 

This is useful if publish events are relatively rare and requests are often left hanging for long amounts of time.