### PR TITLE
Update Redis configuration parameter in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Example of sending events:
     from flask_sse import sse
 
     app = Flask(__name__)
-    app.config["REDIS_URL"] = "redis://localhost"
+    app.config["SSE_REDIS_URL"] = "redis://localhost"
     app.register_blueprint(sse, url_prefix='/stream')
 
     @app.route('/send')

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -26,11 +26,11 @@ like this:
     from flask import Flask
 
     app = Flask(__name__)
-    app.config["REDIS_URL"] = os.environ.get("REDIS_URL")
+    app.config["SSE_REDIS_URL"] = os.environ.get("SSE_REDIS_URL")
 
 If you are using a Redis server that has a password use::
 
-    app.config["REDIS_URL"] = "redis://:password@localhost"
+    app.config["SSE_REDIS_URL"] = "redis://:password@localhost"
 
 Application Server
 ------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -31,7 +31,7 @@ Make a file on your computer called ``sse.py``, with the following content:
     from flask_sse import sse
 
     app = Flask(__name__)
-    app.config["REDIS_URL"] = "redis://localhost"
+    app.config["SSE_REDIS_URL"] = "redis://localhost"
     app.register_blueprint(sse, url_prefix='/stream')
 
     @app.route('/')
@@ -45,7 +45,7 @@ Make a file on your computer called ``sse.py``, with the following content:
 
 If you are using a Redis server that has a password use::
 
-    app.config["REDIS_URL"] = "redis://:password@localhost"
+    app.config["SSE_REDIS_URL"] = "redis://:password@localhost"
 
 Make a ``templates`` folder next to ``sse.py``, and create a file named
 ``index.html`` in that folder, with the following content:


### PR DESCRIPTION
Since we use `SSE_REDIS_URL` over `REDIS_URL`, it's better to use `SSE_REDIS_URL` in documentation. 