### PR TITLE
Issue #6 Redis clients not disconnecting

### DIFF
--- a/flask_sse.py
+++ b/flask_sse.py
@@ -142,7 +142,10 @@ class ServerSentEventsBlueprint(Blueprint):
                     msg_dict = json.loads(pubsub_message['data'])
                     yield Message(**msg_dict)
         finally:
-            pubsub.unsubscribe(channel)
+            try:
+                pubsub.unsubscribe(channel)
+            except redis_exceptions.ConnectionError:
+                pass
 
     def stream(self):
         """

--- a/flask_sse.py
+++ b/flask_sse.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 from flask import Blueprint, request, current_app, json, stream_with_context
 from redis import StrictRedis
-from redis import exceptions as redis_exceptions
+from redis.exceptions import ConnectionError
 import six
 
 __version__ = '0.2.1'

--- a/flask_sse.py
+++ b/flask_sse.py
@@ -144,7 +144,7 @@ class ServerSentEventsBlueprint(Blueprint):
         finally:
             try:
                 pubsub.unsubscribe(channel)
-            except redis_exceptions.ConnectionError:
+            except ConnectionError:
                 pass
 
     def stream(self):

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -96,6 +96,7 @@ def test_messages_channel(bp, app, mockredis):
             "data": '{"data": "whee", "id": "abc"}',
         }
     ]
+    pubsub.unsubscribe.side_effect = redis.exceptions.ConnectionError()
 
     gen = bp.messages('whee')
 


### PR DESCRIPTION
Solution: UNSUBSCRIBE and disconnect from Redis on message generator.close() event

Problem:
1. HTTP client to HTTP server: GET /stream
2. HTTP server to Redis server: SUBSCRIBE
3. HTTP client sends TCP FIN
4. Redis client to Redis server: PUBLISH <message1>
5. Flask SSE pubsub.listen yields message1
6. HTTP Response cannot be sent to HTTP client
7. Flask SSE generator.close() gets called

Note: HTTP server will continue to send Response while the front TCP connection
is not CLOSED. If no message gets published after HTTP client has disconnected,
the connection will remain in CLOSE_WAIT state, and therefore Redis client will
remain connected and subscribed. A periodic health check (to be ignored by
HTTP client) gets around this issue.