### PR TITLE
docs: blueprint MUST be registered after `before_request` handler

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -53,3 +53,11 @@ access control. For example:
     def check_access():
         if request.args.get("channel") == "analytics" and not g.user.is_admin():
             abort(403)
+
+    app.register_blueprint(sse, url_prefix='/sse')
+
+.. warning::
+
+   When defining a :meth:`~flask.Blueprint.before_request` handler, the blueprint
+   must be registered *after* the handler is defined! Otherwise, the handler will
+   have no effect.


### PR DESCRIPTION
see https://cmsdk.com/python/flask-doesn39t-call-blueprint39s-beforerequest-function.html